### PR TITLE
Implement a test function for add_champion_to_team

### DIFF
--- a/teamfight_tactics/tests/tft_test.move
+++ b/teamfight_tactics/tests/tft_test.move
@@ -3,6 +3,7 @@ module teamfight_tactics::tft_test {
   // import anything related to the tests we want to run
   use sui::test_scenario::{Self as ts};
   use sui::transfer;
+  use sui::table;
   use teamfight_tactics::tft::{Self as tft, Player};
   use sui::object;
   use std::string::{utf8, String};
@@ -95,14 +96,48 @@ module teamfight_tactics::tft_test {
   // - mints a new champion object
   // - adds the champion to the player's team
   // - return all necessary objects to their owners
-  // #[test]
-  // fun test_add_champion_to_team() { 
-  //   let test_scenario = ts::begin(ADMIN);
-  //   tft::test_init(ts::ctx(&mut test_scenario));
-  //   ts::next_tx(&mut test_scenario, ADMIN);
 
+  #[test]
+  fun test_add_champion_to_team() { 
+    // Create test scenario for the Admin
+    let admin_test_scenario = ts::begin(ADMIN);
+    let user_test_scenario = ts::begin(USER);
 
-  //   ts::end(test_scenario);
-  // }
+    // Run the test_init to issue an admincap to the admin
+    tft::test_init(ts::ctx(&mut admin_test_scenario));
+
+    // Create a player object and transfer it to the user's player
+    let player = tft::mint_player(utf8(b"Zilean"), 
+      ts::ctx(&mut user_test_scenario));
+    
+    ts::next_tx(&mut user_test_scenario, USER);
+    transfer::public_transfer(player, USER);
+
+    // Mint a new champion object
+    let admin_cap = ts::take_from_sender<tft::AdminCap>(&admin_test_scenario);  // Warning! Anything you take, you must send back to user (consume)
+    ts::next_tx(&mut admin_test_scenario, ADMIN);
+    let champion = tft::admin_mint_champion(
+      &admin_cap,
+      utf8(b"Soraka"), 1, 8, 1, 14,
+      vector<String>[utf8(b"Divine"), utf8(b"Mystic")],
+      ); // Who's the owner of this champion?
+
+    // TODO Add Soraka to the champion pool - WARNING: Champion pool is a shared object!
+    let champion_pool = ts::take_shared<tft::ChampionPool>(&admin_test_scenario);
+    table::add(&mut champion_pool.champions, utf8(b"Soraka"), champion);
+
+    // Add it to the player's team
+    tft::add_champion_to_team(
+      &mut player, 
+      &mut champion_pool,
+      utf8(b"Soraka")
+      );
+
+    // TODO: Consume (e.g. delete/burn) the champion pool object
+    
+    ts::end(user_test_scenario);
+    ts::return_to_sender(&admin_test_scenario, admin_cap);
+    ts::end(admin_test_scenario);
+  }
 
 }

--- a/teamfight_tactics/tests/tft_test.move
+++ b/teamfight_tactics/tests/tft_test.move
@@ -5,7 +5,7 @@ module teamfight_tactics::tft_test {
   use sui::transfer;
   use teamfight_tactics::tft::{Self as tft, Player};
   use sui::object;
-  use std::string::{utf8};
+  use std::string::{utf8, String};
   use std::debug;
 
   const ADMIN: address = @0x01;
@@ -19,7 +19,6 @@ module teamfight_tactics::tft_test {
     // Mint a new player object
     let playerObj = tft::mint_player(
       utf8(b"Alex"),
-      utf8(b"image.com"),
       ts::ctx(&mut test_scenario)
     );
 
@@ -66,11 +65,15 @@ module teamfight_tactics::tft_test {
     
     // Mint a new champion object
     ts::next_tx(&mut test_scenario, ADMIN);
-    let champ = tft::mint_champion(
+    let champ = tft::admin_mint_champion(
       &admin_cap,
       utf8(b"Soraka"),
-      utf8(b"image.com"),
-    );
+      1,
+      8,
+      1, 
+      14,
+      vector<String>[utf8(b"Divine"), utf8(b"Mystic")],
+      );
 
     // Transfer champion to user
     ts::next_tx(&mut test_scenario, ADMIN);
@@ -92,4 +95,14 @@ module teamfight_tactics::tft_test {
   // - mints a new champion object
   // - adds the champion to the player's team
   // - return all necessary objects to their owners
+  // #[test]
+  // fun test_add_champion_to_team() { 
+  //   let test_scenario = ts::begin(ADMIN);
+  //   tft::test_init(ts::ctx(&mut test_scenario));
+  //   ts::next_tx(&mut test_scenario, ADMIN);
+
+
+  //   ts::end(test_scenario);
+  // }
+
 }


### PR DESCRIPTION
Implement a test function that:
- runs the test init, to issue an admincap to the admin
- mints a player object and transfers to the user
- mints a new champion object
- adds the champion to the player's team
- return all necessary objects to their owners